### PR TITLE
Fix wrong category average for months with no such expenses

### DIFF
--- a/modules/m_categories_barchart.R
+++ b/modules/m_categories_barchart.R
@@ -7,22 +7,16 @@ categories_barchart_UI <- function(id) {
 
 categories_barchart_Server <- function(id, 
                                        individual_expenses,
+                                       number_of_months,
                                        categories_exist = reactive(T)
                                        ) {
   moduleServer(
     id,
     function(input, output, session) {
       stopifnot(is.reactive(individual_expenses))
+      stopifnot(is.reactive(number_of_months))
       stopifnot(is.reactive(categories_exist))
-      
-      no_of_months <- reactive({
-        req(individual_expenses())
-        individual_expenses() %>%
-          cover_all_dates_in_period() %>%
-          group_by(year(Date), month(Date)) %>% 
-          summarise(N = n(), .groups = "drop") %>% nrow()
-      })
-      
+
       plot_data <- reactive({
         req(individual_expenses())
         
@@ -32,7 +26,7 @@ categories_barchart_Server <- function(id,
           # Added empty dates resulted in NA categories
           filter(!is.na(Category)) %>%
           summarise(Amount = sum(Amount) %>% round(),
-                    Monthly_amount = (Amount / no_of_months()) %>% round(),
+                    Monthly_amount = (Amount / number_of_months()) %>% round(),
                     No_expenses = n(), .groups = "drop")
       })
       


### PR DESCRIPTION
Calculate number of selected months in main app
Pass it to the module.
The error occured when e.g. the expenses for a given category didn't start until the third month. Then the inside-module reactive would count two months less than the selected span. Now it's count at root level so it has access to the datespan selectors, and passes the number of months to the module.