### PR TITLE
Moving averages allowed if there are three months, no matter how many days in them have transactions

### DIFF
--- a/modules/m_expenses_over_time_plot.R
+++ b/modules/m_expenses_over_time_plot.R
@@ -61,9 +61,9 @@ expenses_over_time_plotServer <- function(id, expenses_by_day, expenses_by_month
       })
       
       
-      # Calculating three-month trends - only used if enough data is present - 90 days
+      # Calculating three-month trends - only used if enough data is present - 3 months
       # TRUE/FALSE
-      enough_data_ma <- reactive(nrow(expenses_by_day()) >= 90)
+      enough_data_ma <- reactive(nrow(expenses_by_month()) >= 3)
       
       show_trend <- reactiveVal(T)
       


### PR DESCRIPTION
not necessarily 90 days, which isn't important if we don't allow daily MA